### PR TITLE
Add Smithery to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,21 @@
 # MCP GitHub Issue Server
+[![smithery badge](https://smithery.ai/badge/mcp-github-issue)](https://smithery.ai/protocol/mcp-github-issue)
 
 An MCP server that provides LLMs with the ability to use GitHub issues as the task to complete. This server allows LLMs to fetch GitHub issue details and use them as task descriptions.
 
 ## Installation
 
+### Installing via Smithery
+
+To install MCP GitHub Issue Server for Claude Desktop automatically via [Smithery](https://smithery.ai/protocol/mcp-github-issue):
+
 ```bash
-npx -y mcp-github-issue
+npx @smithery/cli install mcp-github-issue --client claude
+```
+
+### Manual Installation
+```bash
+npx mcp-github-issue
 ```
 
 ## Usage
@@ -19,7 +29,7 @@ Add to your MCP configuration:
   "mcpServers": {
     "github-issue": {
       "command": "npx",
-      "args": ["-y", "mcp-github-issue"]
+      "args": ["mcp-github-issue"]
     }
   }
 }


### PR DESCRIPTION
This PR makes two changes to the README.

1. Adds installation instructions to automatically install GitHub Issue for Claude Desktop using Smithery CLI. This makes it easier for users to install the MCP.
2. Adds a badge to show the number of installations from Smithery: https://smithery.ai/server/mcp-github-issue

Let me know if any tweaks have to be made!